### PR TITLE
Ignore Visual Studio Code files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ CMakeLists.txt.user
 build*
 cmake-build*
 cred-macos
+.vscode/
+


### PR DESCRIPTION
A small tweak to ignore the editor-specific local files for Visual Studio Code.