### PR TITLE
Fix manufacturer specific cluster attributes with same ID as default attributes not being displayed/populated correctly

### DIFF
--- a/src/zm_attribute_info.cpp
+++ b/src/zm_attribute_info.cpp
@@ -370,6 +370,7 @@ void zmAttributeInfo::readAttributeResponse(const deCONZ::ZclFrame &zclFrame)
             {
                 //m_attribute.setDataType(dataType);
                 m_attribute.readFromStream(stream);
+                m_attribute.setManufacturerCode(zclFrame.manufacturerCode());
                 updateEdit();
                 ui->status->setText(tr("reading done"));
             }

--- a/src/zm_cluster_info.cpp
+++ b/src/zm_cluster_info.cpp
@@ -433,9 +433,9 @@ void zmClusterInfo::attributeDoubleClicked(const QModelIndex &index)
             const deCONZ::ZclAttribute &attr = cluster->attributes()[i];
             if (attr.id() == id)
             {
-                QString mfc = "0x" + QString("%1").arg(attr.manufacturerCode(), 4, 16, QLatin1Char('0')).toUpper();
+                unsigned mfc = m_attrModel->data(m_attrModel->index(index.row(), 5)).toString().toUInt(nullptr, 0);
 
-                if (mfc == m_attrModel->data(m_attrModel->index(index.row(), 5)).toString())
+                if (attr.manufacturerCode() == mfc)
                 {
                     info->setAttribute(m_endpoint, m_clusterId, m_clusterSide, attr);
                     ok = true;

--- a/src/zm_cluster_info.cpp
+++ b/src/zm_cluster_info.cpp
@@ -52,6 +52,7 @@ zmClusterInfo::zmClusterInfo(QWidget *parent) :
     attrHeaders.append("type");
     attrHeaders.append("access");
     attrHeaders.append("value");
+    attrHeaders.append("mfc");
 
     m_attrModel->setHorizontalHeaderLabels(attrHeaders);
 
@@ -743,7 +744,7 @@ void zmClusterInfo::showAttributes()
     {
         m_attrModel->setRowCount(0);
         //m_attrModel->setRowCount(m_cluster.attributes().size() + m_cluster.attributeSets().size());
-        m_attrModel->setColumnCount(5);
+        m_attrModel->setColumnCount(6);
         ui->attrTableView->horizontalHeader()->stretchLastSection();
     }
 
@@ -793,7 +794,7 @@ void zmClusterInfo::showAttributes()
                 m_attrModel->item(row, 1)->setBackground(palette().dark().color().lighter(120));
                 m_attrModel->item(row, 1)->setForeground(palette().brightText());
 
-                ui->attrTableView->setSpan(row, 1 , 1, 4);
+                ui->attrTableView->setSpan(row, 1 , 1, 5);
 
                 row++;
             }
@@ -839,6 +840,9 @@ void zmClusterInfo::showAttributes()
 
                     data = attr.toString(dataType, deCONZ::ZclAttribute::Prefix);
                     m_attrModel->setData(m_attrModel->index(row, 4), data);
+                    
+                    QString mfc = "0x" + QString("%1").arg(attr.manufacturerCode(), 4, 16, QLatin1Char('0')).toUpper();
+                    m_attrModel->setData(m_attrModel->index(row, 5), mfc);
 
                     // visual difference if a attribute is available
                     for (int j = 0; j < m_attrModel->columnCount(); j++)
@@ -888,6 +892,9 @@ void zmClusterInfo::showAttributes()
 
             data = attr.toString(dataType, deCONZ::ZclAttribute::Prefix);
             m_attrModel->setData(m_attrModel->index(i, 4), data);
+            
+            QString mfc = "0x" + QString("%1").arg(attr.manufacturerCode(), 4, 16, QLatin1Char('0')).toUpper();
+            m_attrModel->setData(m_attrModel->index(row, 5), mfc);
 
             // visual difference if a attribute is available
             for (int j = 0; j < m_attrModel->columnCount(); j++)
@@ -904,6 +911,7 @@ void zmClusterInfo::showAttributes()
         ui->attrTableView->resizeColumnToContents(2);
         ui->attrTableView->resizeColumnToContents(3);
         ui->attrTableView->resizeColumnToContents(4);
+        ui->attrTableView->setColumnHidden(5, true);
         ui->attrTableView->resizeRowsToContents();
         ui->attrTableView->horizontalHeader()->setStretchLastSection(true);
         m_init = true;

--- a/src/zm_cluster_info.cpp
+++ b/src/zm_cluster_info.cpp
@@ -862,10 +862,8 @@ void zmClusterInfo::showAttributes()
     }
     else
     {
-        for (uint i = 0; i < cluster->attributes().size(); i++)
+        for (const auto &attr : cluster->attributes())
         {
-            const deCONZ::ZclAttribute &attr =  cluster->attributes()[i];
-
             if (discoveredOnly && !attr.isAvailable())
             {
                 continue;
@@ -888,24 +886,26 @@ void zmClusterInfo::showAttributes()
                 m_attrModel->setRowCount(m_attrModel->rowCount() + 1);
             }
 
-            m_attrModel->setData(m_attrModel->index(i, 0), aid);
-            m_attrModel->item(i, 0)->setData((uint)attr.id());
+            m_attrModel->setData(m_attrModel->index(row, 0), aid);
+            m_attrModel->item(row, 0)->setData((uint)attr.id());
 
-            m_attrModel->setData(m_attrModel->index(i, 1), attr.name());
-            m_attrModel->setData(m_attrModel->index(i, 2), dataType.shortname());
-            m_attrModel->setData(m_attrModel->index(i, 3), attr.isReadonly() ? "r" : "rw");
+            m_attrModel->setData(m_attrModel->index(row, 1), attr.name());
+            m_attrModel->setData(m_attrModel->index(row, 2), dataType.shortname());
+            m_attrModel->setData(m_attrModel->index(row, 3), attr.isReadonly() ? "r" : "rw");
 
             data = attr.toString(dataType, deCONZ::ZclAttribute::Prefix);
-            m_attrModel->setData(m_attrModel->index(i, 4), data);
-            
+            m_attrModel->setData(m_attrModel->index(row, 4), data);
+
             QString mfc = "0x" + QString("%1").arg(attr.manufacturerCode(), 4, 16, QLatin1Char('0')).toUpper();
             m_attrModel->setData(m_attrModel->index(row, 5), mfc);
 
             // visual difference if a attribute is available
             for (int j = 0; j < m_attrModel->columnCount(); j++)
             {
-                m_attrModel->item(i, j)->setEnabled(attr.isAvailable());
+                m_attrModel->item(row, j)->setEnabled(attr.isAvailable());
             }
+
+            row++;
         }
     }
 

--- a/src/zm_cluster_info.cpp
+++ b/src/zm_cluster_info.cpp
@@ -433,9 +433,14 @@ void zmClusterInfo::attributeDoubleClicked(const QModelIndex &index)
             const deCONZ::ZclAttribute &attr = cluster->attributes()[i];
             if (attr.id() == id)
             {
-                info->setAttribute(m_endpoint, m_clusterId, m_clusterSide, attr);
-                ok = true;
-                break;
+                QString mfc = "0x" + QString("%1").arg(attr.manufacturerCode(), 4, 16, QLatin1Char('0')).toUpper();
+
+                if (mfc == m_attrModel->data(m_attrModel->index(index.row(), 5)).toString())
+                {
+                    info->setAttribute(m_endpoint, m_clusterId, m_clusterSide, attr);
+                    ok = true;
+                    break;
+                }
             }
         }
 

--- a/src/zm_controller.cpp
+++ b/src/zm_controller.cpp
@@ -6467,6 +6467,8 @@ void zmController::zclReadAttributesResponse(NodeInfo *node, const deCONZ::ApsDa
         {
             for (auto &a : cluster->attributes())
             {
+                // Keep an eye on this part if anything weird shows up. Eventually extend by also checking frame options + mfc 0x0000
+                // Also see: https://github.com/dresden-elektronik/deconz/pull/2#discussion_r1694968173
                 if (a.id() == id && a.manufacturerCode() == zclFrame.manufacturerCode())
                 {
                     attr = &a;

--- a/src/zm_controller.cpp
+++ b/src/zm_controller.cpp
@@ -6489,9 +6489,9 @@ void zmController::zclReadAttributesResponse(NodeInfo *node, const deCONZ::ApsDa
             if (dataType != attr->dataType())
             {
                 DBG_Printf(DBG_ZCL, "ZCL Read Attributes node=0x%04X, error assumed data type "
-                       " 0x%02X but got 0x%02X for at=0x%04X\n",
+                       " 0x%02X but got 0x%02X for at=0x%04X, mfc=0x%04X\n",
                        node->data->address().nwk(),
-                       attr->dataType(), dataType, attr->id());
+                       attr->dataType(), dataType, attr->id(), attr->manufacturerCode());
 
                 // disabled by stack
                 if (dataType == deCONZ::ZclNoData)
@@ -6555,10 +6555,10 @@ void zmController::zclReadAttributesResponse(NodeInfo *node, const deCONZ::ApsDa
             attr->setAvailable(false); // disable fetching
         }
 
-        DBG_Printf(DBG_ZCL, "ZCL got data for node=0x%04X, cl=0x%04X, at=0x%04X, status=0x%02X, type=0x%02X\n",
+        DBG_Printf(DBG_ZCL, "ZCL got data for node=0x%04X, cl=0x%04X, at=0x%04X, mfc=0x%04X, status=0x%02X, type=0x%02X\n",
                node->data->address().nwk(),
                ind.clusterId(),
-               attr->id(), status, dataType);
+               attr->id(), attr->manufacturerCode(), status, dataType);
     }
 
     DBG_Assert(node && node->data && cluster);

--- a/src/zm_controller.cpp
+++ b/src/zm_controller.cpp
@@ -6465,16 +6465,10 @@ void zmController::zclReadAttributesResponse(NodeInfo *node, const deCONZ::ApsDa
 
         if (cluster)
         {
-            for (uint i = 0; i < cluster->attributes().size(); i++)
+            for (auto &a : cluster->attributes())
             {
-                auto &a = cluster->attributes()[i];
-                if (a.id() == id)
+                if (a.id() == id && a.manufacturerCode() == zclFrame.manufacturerCode())
                 {
-                    if (a.isManufacturerSpecific() && a.manufacturerCode() != zclFrame.manufacturerCode())
-                    {
-                        continue;
-                    }
-
                     attr = &a;
                     break;
                 }


### PR DESCRIPTION
Although quite rare, probably one of the most annoying bugs in deconz GUI... until now. Whenever there were attribute IDs within the same cluster having no and a manufacturer specific code, the GUI wasn't able to display and update if correctly. This eventually led to a condition where devices couldn't be configured or only by manually editing `general.xml` file.

This PR finally fixes this. Was tested with a Philips motion sensor.

![grafik](https://github.com/user-attachments/assets/3b25dd86-c9da-476d-9e17-7f0d142a301e)
