### PR TITLE
Expose only fitting mf specific commands per node

### DIFF
--- a/src/zm_cluster_info.cpp
+++ b/src/zm_cluster_info.cpp
@@ -155,7 +155,7 @@ void zmClusterInfo::showCluster(quint16 id, deCONZ::ZclClusterSide clusterSide)
         ui->clusterGroupBox->setTitle(cluster->name() + " Cluster");
         ui->clusterDescription->setText(cluster->description());
         showAttributes();
-        ui->commandInfo->setCluster(sd->profileId(), *cluster, m_clusterSide);
+        ui->commandInfo->setCluster(sd->profileId(), *cluster, m_clusterSide, m_node);
         return;
     }
 
@@ -188,7 +188,7 @@ void zmClusterInfo::refresh()
             if (cluster)
             {
                 showAttributes();
-                ui->commandInfo->setCluster(sd->profileId(), *cluster, m_clusterSide);
+                ui->commandInfo->setCluster(sd->profileId(), *cluster, m_clusterSide, m_node);
             }
         }
     }
@@ -217,7 +217,7 @@ void zmClusterInfo::refreshNodeCommands(deCONZ::zmNode *node, deCONZ::ZclCluster
 
         if (sd && cl)
         {
-            ui->commandInfo->setCluster(sd->profileId(), *cl, m_clusterSide);
+            ui->commandInfo->setCluster(sd->profileId(), *cl, m_clusterSide, m_node);
         }
     }
 }

--- a/src/zm_command_info.h
+++ b/src/zm_command_info.h
@@ -24,6 +24,7 @@ namespace deCONZ
 class ApsDataIndication;
 }
 
+class zmNode;
 class QPushButton;
 class QLabel;
 class QVBoxLayout;
@@ -36,7 +37,7 @@ class zmCommandInfo : public QWidget
 public:
     explicit zmCommandInfo(QWidget *parent = 0);
     ~zmCommandInfo();
-    void setCluster(quint16 profileId, const deCONZ::ZclCluster &cluster, deCONZ::ZclClusterSide side);
+    void setCluster(quint16 profileId, const deCONZ::ZclCluster &cluster, deCONZ::ZclClusterSide side, deCONZ::zmNode *node);
 
 public Q_SLOTS:
     void onExec(int commandId);
@@ -98,6 +99,7 @@ private:
     deCONZ::ZclCluster m_clusterOpposite;
     QList<CommandDescriptor> m_cache;
     QSignalMapper *m_execMapper;
+    deCONZ::zmNode *m_node = nullptr;
 };
 
 #endif // ZM_COMMAND_INFO_H


### PR DESCRIPTION
This PR shall ensure that only the correct manufacturer specific commands are exposed per node within the clusters. This is ensured by checking the node mfc.