### PR TITLE
Fix - Correct attribute access display in attribute and cluster view

### DIFF
--- a/src/zm_attribute_info.cpp
+++ b/src/zm_attribute_info.cpp
@@ -468,7 +468,7 @@ void zmAttributeInfo::setAttribute(quint8 endpoint, quint16 clusterId, deCONZ::Z
 {
     setWindowTitle(tr("Attribute Editor"));
     ui->attributeName->setText(attr.name());
-    ui->attributeAccess->setText(attr.isReadonly() ? "read only" : "writeable");
+    ui->attributeAccess->setText(attr.isReadonly() ? "read only" : (attr.isWriteonly() ? "write only" : "read/write"));
     m_endpoint = endpoint;
     m_clusterId = clusterId;
     m_clusterSide = clusterSide;

--- a/src/zm_cluster_info.cpp
+++ b/src/zm_cluster_info.cpp
@@ -842,7 +842,7 @@ void zmClusterInfo::showAttributes()
 
                     m_attrModel->setData(m_attrModel->index(row, 1), attr.name());
                     m_attrModel->setData(m_attrModel->index(row, 2), dataType.shortname());
-                    m_attrModel->setData(m_attrModel->index(row, 3), attr.isReadonly() ? "r" : "rw");
+                    m_attrModel->setData(m_attrModel->index(row, 3), attr.isReadonly() ? "r" : (attr.isWriteonly() ? "w" : "rw"));
 
                     data = attr.toString(dataType, deCONZ::ZclAttribute::Prefix);
                     m_attrModel->setData(m_attrModel->index(row, 4), data);
@@ -892,7 +892,7 @@ void zmClusterInfo::showAttributes()
 
             m_attrModel->setData(m_attrModel->index(row, 1), attr.name());
             m_attrModel->setData(m_attrModel->index(row, 2), dataType.shortname());
-            m_attrModel->setData(m_attrModel->index(row, 3), attr.isReadonly() ? "r" : "rw");
+            m_attrModel->setData(m_attrModel->index(row, 3), attr.isReadonly() ? "r" : (attr.isWriteonly() ? "w" : "rw"));
 
             data = attr.toString(dataType, deCONZ::ZclAttribute::Prefix);
             m_attrModel->setData(m_attrModel->index(row, 4), data);


### PR DESCRIPTION
Write only attribute access ("w") was incorrectly displayed as read/write access ("rw"). This will now be displayed correctly in attribute and cluster view.

**Depends on https://github.com/dresden-elektronik/deconz-lib/pull/4**

<img width="554" height="168" alt="image" src="https://github.com/user-attachments/assets/c34b022b-1f21-46a2-9871-609eb196cc73" />

<img width="382" height="347" alt="image" src="https://github.com/user-attachments/assets/5109ddd0-b25e-4f60-9667-8aa855da8be5" />
