### PR TITLE
Fix - Disable read button when attribute is write only

### DIFF
--- a/src/zm_attribute_info.cpp
+++ b/src/zm_attribute_info.cpp
@@ -173,7 +173,17 @@ void zmAttributeInfo::stateCheck()
         {
             ui->writeButton->setEnabled(true);
         }
-        ui->readButton->setEnabled(true);
+
+        if (m_attribute.isWriteonly())
+        {
+            //ui->writeButton->setEnabled(false);
+            ui->readButton->setEnabled(false);
+        }
+        else
+        {
+            ui->readButton->setEnabled(true);
+        }
+
         ui->readReportConfButton->setEnabled(true);
         ui->writeReportConfButton->setEnabled(true);
         break;


### PR DESCRIPTION
Align button behavior. When attribute is read only, write button is disabled. On the other hand, read button is not disabled if attribute is write only.

With this PR, read button is disabled.

<img width="660" height="521" alt="image" src="https://github.com/user-attachments/assets/88adf51b-addd-4629-8fd1-69fbf7899133" />
