### PR TITLE
Fix - Enable writing cstring attribute values

### DIFF
--- a/src/zm_attribute_info.cpp
+++ b/src/zm_attribute_info.cpp
@@ -857,12 +857,7 @@ bool zmAttributeInfo::getNumericInput()
         }
         else if (m_attribute.dataType() == deCONZ::ZclCharacterString)
         {
-            const QByteArray str = edit->text().toLatin1();
-
-            if (str.isEmpty())
-            {
-                return false;
-            }
+            const QByteArray str = edit->text().toUtf8();
 
             m_attribute.setValue(QVariant(str));
             return true;

--- a/src/zm_attribute_info.cpp
+++ b/src/zm_attribute_info.cpp
@@ -262,6 +262,7 @@ void zmAttributeInfo::write()
     case deCONZ::Zcl128BitSecurityKey:
     case deCONZ::ZclSingleFloat:
     case deCONZ::ZclOctedString:
+    case deCONZ::ZclCharacterString:
         ok = getNumericInput();
         break;
 
@@ -561,6 +562,7 @@ void zmAttributeInfo::setAttribute(quint8 endpoint, quint16 clusterId, deCONZ::Z
     case deCONZ::Zcl128BitSecurityKey:
     case deCONZ::ZclSingleFloat:
     case deCONZ::ZclOctedString:
+    case deCONZ::ZclCharacterString:
         buildNumericInput();
         break;
 
@@ -627,6 +629,7 @@ void zmAttributeInfo::updateEdit()
     case deCONZ::Zcl128BitSecurityKey:
     case deCONZ::ZclSingleFloat:
     case deCONZ::ZclOctedString:
+    case deCONZ::ZclCharacterString:
         setNumericInput();
         break;
 
@@ -851,6 +854,18 @@ bool zmAttributeInfo::getNumericInput()
                 return true;
             }
             return false;
+        }
+        else if (m_attribute.dataType() == deCONZ::ZclCharacterString)
+        {
+            const QByteArray str = edit->text().toLatin1();
+
+            if (str.isEmpty())
+            {
+                return false;
+            }
+
+            m_attribute.setValue(QVariant(str));
+            return true;
         }
 
         if (m_signed)


### PR DESCRIPTION
Currently, there is no input field available if cstring values shall be written to a respective attribute. The PR provides an input field and allows writing strings to the corresponding fields.

<img width="401" height="384" alt="image" src="https://github.com/user-attachments/assets/35f70c6a-03ae-478d-842b-059785c9dfd0" />
